### PR TITLE
startup_gcc.c: ensure stack pointer is 8-byte aligned

### DIFF
--- a/cores/cc3200/startup_gcc.c
+++ b/cores/cc3200/startup_gcc.c
@@ -116,7 +116,7 @@ __attribute__((weak)) void I2CIntHandler(void) {}
 // Reserve space for the system stack.
 //
 //*****************************************************************************
-static uint32_t pui32Stack[8192];
+static uint32_t pui32Stack[8192] __attribute__ ((aligned(8)));
 
 //*****************************************************************************
 //


### PR DESCRIPTION
The ARM Architecture Procedure Call Standard (AAPCS) requires the stack pointer to be aligned to an 8-byte boundary on every function entry and exit. If this requirement is not satisfied, some functions may behave erroneously, for example the printf() standard library function fails to correctly handle long long and unsigned long long arguments.
In order to satisfy the above requirement, the initial value of the stack pointer set during startup must be 8-byte aligned, and this can be achieved by declaring the pui32Stack array in startup_gcc.c with __attribute__ ((aligned(8))).