### PR TITLE
WiFiClient::stop(): reset reception buffer

### DIFF
--- a/libraries/WiFi/WiFiClient.cpp
+++ b/libraries/WiFi/WiFiClient.cpp
@@ -527,6 +527,8 @@ void WiFiClient::stop()
     WiFiClass::_handleArray[_socketIndex] = -1;
     WiFiClass::_typeArray[_socketIndex] = -1;
     _socketIndex = NO_SOCKET_AVAIL;
+    rx_fillLevel = 0;
+    rx_currentIndex = 0;
     
 }
 


### PR DESCRIPTION
When stop() is called on a client to disconnect it from the server, any unread data should be discarded, otherwise if the client is connected again later, the first data read from it will be the unread data from the previous connection.